### PR TITLE
Fix Memory Leak in ExampleSideMenuViewController

### DIFF
--- a/Sources/DrawerPresentation/DrawerTransitionController.swift
+++ b/Sources/DrawerPresentation/DrawerTransitionController.swift
@@ -97,7 +97,7 @@ public final class DrawerTransitionController: NSObject {
 extension DrawerTransitionController: UIViewControllerTransitioningDelegate {
     
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> (any UIViewControllerAnimatedTransitioning)? {
-        animator.onTapDimmingView = { presented.dismiss(animated: true) }
+        animator.onTapDimmingView = { [weak presented] in presented?.dismiss(animated: true) }
         animator.onDismissGesture = { [weak presented] gesture in
             switch gesture.state {
             case .began:


### PR DESCRIPTION
## Issue Number
https://github.com/noppefoxwolf/DrawerPresentation/issues/1

## Implementation Summary
This PR fixes the memory leak issue that occurred in the `ExampleSideMenuViewController`. The issue was caused by a strong reference by the `animator.onTapDimmingView`.

To resolve this, the code introduces weak references to the presented view controller inside the closures assigned to `animator.onTapDimmingView`. This ensures that the presented view controller can be properly deallocated when dismissed.

## Reference
https://github.com/user-attachments/assets/1b50d713-6ff9-4907-93ea-566007e392c3

